### PR TITLE
Add prettier config and fix types

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+	"trailingComma": "es5",
+	"singleQuote": true,
+	"semi": false,
+	"printWidth": 100,
+	"tabWidth": 2,
+	"useTabs": true,
+	"plugins": ["prettier-plugin-organize-imports"]
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"tldraw": "3.0.3"
 	},
 	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20240909.0",
 		"@types/lodash.throttle": "^4",
 		"@types/react": "^18.0.37",
 		"@types/react-dom": "^18.0.11",
@@ -40,6 +41,8 @@
 		"eslint": "^8.38.0",
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"eslint-plugin-react-refresh": "^0.3.4",
+		"prettier": "^3.3.3",
+		"prettier-plugin-organize-imports": "^4.0.0",
 		"typescript": "^5.0.2",
 		"vite": "^5.4.2",
 		"wrangler": "^3.64.0"


### PR DESCRIPTION
Add the Prettier config file from https://github.com/tldraw/tldraw/blob/main/.prettierrc, and install its dev dependencies to fix the code formatting.

Also add `@cloudflare/workers-types` to fix the worker types.

Please update `yarn.lock` after merging this! (it seems quite a bit out of date)