### PR TITLE
Add worker name to wrangler.toml to fix deploy

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,4 @@
+name = "tldraw-worker"
 main = "worker/worker.ts"
 compatibility_date = "2024-07-01"
 


### PR DESCRIPTION
Running `yarn wrangler deploy` produces the following error on `main`:

```
✘ [ERROR] You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`
```

To fix this, add a worker `name` to `wrangler.toml`.